### PR TITLE
fix: remove pytest runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "pytest-runner"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

pytest-runner is used to setup scripts that can use pytest-runner to add setup.py test support for pytest runner. 

This project does not use a setup.py script

### Testing

NA

### Special notes

NA

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
