### PR TITLE
feat: include the target runtime in the get-hooks response

### DIFF
--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -22,6 +22,7 @@ hooks_payload = {
         "protocol-version": [MessageBoundaryProtocol.name, DefaultProtocol.name],
         "sdk-managed-connection-enabled": True,
     },
+    "runtime": "python",
 }
 
 if __name__ == "__main__":

--- a/tests/slack_cli_hooks/hooks/test_get_hooks.py
+++ b/tests/slack_cli_hooks/hooks/test_get_hooks.py
@@ -23,3 +23,7 @@ class TestGetHooks:
 
         filter_regex = config["watch"]["filter-regex"]
         assert re.match(filter_regex, "manifest.json") is not None
+
+    def test_hooks_runtime(self):
+        runtime = hooks_payload["runtime"]
+        assert runtime == "python"

--- a/tests/slack_cli_hooks/hooks/test_get_hooks.py
+++ b/tests/slack_cli_hooks/hooks/test_get_hooks.py
@@ -26,4 +26,5 @@ class TestGetHooks:
 
     def test_hooks_runtime(self):
         runtime = hooks_payload["runtime"]
+
         assert runtime == "python"


### PR DESCRIPTION
### Summary

This PR includes the `runtime` attribute in the `get-hooks` response so that the CLI can recognize the runtime of a project.

### Special notes

I believe `python` is the runtime and `python3` is the executable, but please correct me if not!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
