### PR TITLE
feat: return runtime versions used by the application with a doctor hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ The CLI will always use the version of the `python-slack-hooks` that is specifie
 
 ### Supported Hooks
 
-The hooks currently supported for use within the Slack CLI include `check-update`, `get-hooks`, `get-manifest`, and `start`:
+The hooks currently supported for use within the Slack CLI include `check-update`, `doctor`, `get-hooks`, `get-manifest`, and `start`:
 
 | Hook Name  | CLI Command  | File  |  Description  |
 | --- | --- | --- | --- |
 | `check-update` | `slack update` | [check_update.py](./slack_cli_hooks/hooks/check_update.py) | Checks the project's Slack dependencies to determine whether or not any libraries need to be updated. |
+| `doctor` | `slack doctor` | [doctor.py](./slack_cli_hooks/hooks/doctor.py) | Returns runtime versions and other system dependencies required by the application. |
 | `get-hooks` | All | [get_hooks.py](./slack_cli_hooks/hooks/get_hooks.py) | Fetches the list of available hooks for the CLI from this repository. |
 | `get-manifest` | `slack manifest` | [get_manifest.py](./slack_cli_hooks/hooks/get_manifest.py) | Converts a `manifest.json` file into a valid manifest JSON payload. |
 | `start` | `slack run` | [start.py](./slack_cli_hooks/hooks/start.py) | While developing locally, the CLI manages a socket connection with Slack's backend and utilizes this hook for events received via this connection. |

--- a/slack_cli_hooks/hooks/doctor.py
+++ b/slack_cli_hooks/hooks/doctor.py
@@ -14,7 +14,7 @@ doctor_payload = {
     "versions": [
         {
             "name": "python",
-            "current": platform.python_build()[0],
+            "current": platform.python_version(),
         },
         {
             "name": "implementation",

--- a/slack_cli_hooks/hooks/doctor.py
+++ b/slack_cli_hooks/hooks/doctor.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import json
+import platform
+
+from slack_cli_hooks.protocol import (
+    Protocol,
+    build_protocol,
+)
+
+PROTOCOL: Protocol
+
+
+doctor_payload = {
+    "versions": [
+        {
+            "name": "python",
+            "current": platform.python_build()[0],
+        },
+        {
+            "name": "implementation",
+            "current": platform.python_implementation(),
+        },
+        {
+            "name": "compiler",
+            "current": platform.python_compiler(),
+        },
+    ],
+}
+
+if __name__ == "__main__":
+    PROTOCOL = build_protocol()
+    PROTOCOL.respond(json.dumps(doctor_payload))

--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -16,6 +16,7 @@ hooks_payload = {
         "get-manifest": f"{EXEC} -m slack_cli_hooks.hooks.get_manifest",
         "start": f"{EXEC} -X dev -m slack_cli_hooks.hooks.start",
         "check-update": f"{EXEC} -m slack_cli_hooks.hooks.check_update",
+        "doctor": f"{EXEC} -m slack_cli_hooks.hooks.doctor",
     },
     "config": {
         "watch": {"filter-regex": "(^manifest\\.json$)", "paths": ["."]},

--- a/tests/slack_cli_hooks/hooks/test_doctor.py
+++ b/tests/slack_cli_hooks/hooks/test_doctor.py
@@ -8,9 +8,9 @@ class TestDoctor:
         versions = doctor_payload.get("versions")
         assert versions is not None
 
-        assert versions[0].get("name") is "python"
-        assert versions[0].get("current") is platform.python_build()[0]
-        assert versions[1].get("name") is "implementation"
-        assert versions[1].get("current") is platform.python_implementation()
-        assert versions[2].get("name") is "compiler"
-        assert versions[2].get("current") is platform.python_compiler()
+        assert versions[0].get("name") == "python"
+        assert versions[0].get("current") == platform.python_build()[0]
+        assert versions[1].get("name") == "implementation"
+        assert versions[1].get("current") == platform.python_implementation()
+        assert versions[2].get("name") == "compiler"
+        assert versions[2].get("current") == platform.python_compiler()

--- a/tests/slack_cli_hooks/hooks/test_doctor.py
+++ b/tests/slack_cli_hooks/hooks/test_doctor.py
@@ -1,0 +1,16 @@
+import platform
+
+from slack_cli_hooks.hooks.doctor import doctor_payload
+
+
+class TestDoctor:
+    def test_versions(self):
+        versions = doctor_payload.get("versions")
+        assert versions is not None
+
+        assert versions[0].get("name") is "python"
+        assert versions[0].get("current") is platform.python_build()[0]
+        assert versions[1].get("name") is "implementation"
+        assert versions[1].get("current") is platform.python_implementation()
+        assert versions[2].get("name") is "compiler"
+        assert versions[2].get("current") is platform.python_compiler()

--- a/tests/slack_cli_hooks/hooks/test_doctor.py
+++ b/tests/slack_cli_hooks/hooks/test_doctor.py
@@ -9,7 +9,7 @@ class TestDoctor:
         assert versions is not None
 
         assert versions[0].get("name") == "python"
-        assert versions[0].get("current") == platform.python_build()[0]
+        assert versions[0].get("current") == platform.python_version()
         assert versions[1].get("name") == "implementation"
         assert versions[1].get("current") == platform.python_implementation()
         assert versions[2].get("name") == "compiler"

--- a/tests/slack_cli_hooks/hooks/test_get_hooks.py
+++ b/tests/slack_cli_hooks/hooks/test_get_hooks.py
@@ -9,6 +9,7 @@ class TestGetHooks:
         assert "slack_cli_hooks.hooks.get_manifest" in hooks["get-manifest"]
         assert "slack_cli_hooks.hooks.start" in hooks["start"]
         assert "slack_cli_hooks.hooks.check_update" in hooks["check-update"]
+        assert "slack_cli_hooks.hooks.doctor" in hooks["doctor"]
 
     def test_hooks_payload_config(self):
         config = hooks_payload["config"]


### PR DESCRIPTION
### Summary

This PR introduces a `doctor` hook that returns runtime versions for the application's execution environment in a structured way. The `doctor_payload` demonstrate the expected response shape!

The `python` version is included in this response, as well as the `implementation` type and `compiler` version. All gathered from [the standard `platform` package](https://docs.python.org/3/library/platform.html#platform.python_version).

### Preview

![doctor](https://github.com/slackapi/python-slack-hooks/assets/18134219/15850633-9373-400e-9762-78cc0430ac3e)


### Testing

With a custom build of the CLI, setup a project to use the `doctor` hook:

```sh
$ cd python-slack-hooks
$ git checkout feat-doctor-hook
$ source .venv/bin/activate        # Activate your virtual environment
$ ./scripts/build_pypi_package.sh  # Prepare the package

$ slack create snak -e bolt        # Create a Python application
$ cd snak
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip install -r requirements.txt
$ pip install ~/path/to/python-slack-hooks/dist/slack_cli_hooks-0.0.0.dev2-py3-none-any.whl --force-reinstall
$ slack doctor
```

### Special notes

- IMO `implementation` and `compiler` are nice to have as it makes this section feel complete! But I imagine these are also details that can be useful in troubleshooting. Open to changing any of the included information though!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
