### PR TITLE
fix: introduce the packaging dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 slack_bolt>=1.18.0,<2
+packaging<25


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

This PR aims to resolve #29 where the `packaging` dependency is not installed on the system.

It seems like `pip` which uses the `packaging` project [duplicates the logic](https://github.com/pypa/pip/blob/800c1245bd7d5b3ad3fd52fd84c17a230bfa28e4/src/pip/_vendor/__init__.py#L1C1-L7C1) into its source code rather then installing it as a dependency. Seems like the chicken and egg problem 🥚 

This PR aims to introduce `packaging` as a dependency to the project, alternatively we could duplicate the logic like `pip` does, or find another solution rather then adding our first "real" dependency

### Testing

1. Create a new project with `slack create -t https://github.com/slack-samples/bolt-python-custom-function-template`
2. edit the `requirements.txt` file so that it only contains (many other packages have the `packaging` dependency)
```txt
slack-cli-hooks
slack-bolt==1.19.0rc1
```
3. run `slack update`
4. Everything should work 🟢 

### Special notes

Important to not that many python development tools like `pip`, [`black`](https://github.com/psf/black/blob/735733b20516f2ea849d20f585555bf41a40311f/pyproject.toml#L68) and [`pytest`](https://github.com/pytest-dev/pytest/blob/b56b294f54268b45f611917e6d1fd577a2f848be/pyproject.toml#L45) use the `packaging` project, this is why we did not catch this error sooner

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
