### PR TITLE
fix: improve which python executable is being used 

### DIFF
--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -9,6 +9,8 @@ from slack_cli_hooks.protocol import (
 )
 
 PROTOCOL: Protocol
+
+# Stringify sys.executable to prevent execution failures if a white space is present in the absolute python path
 EXEC = f"'{sys.executable}'" or "python3"
 
 

--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import json
+import sys
 from slack_cli_hooks.protocol import (
     Protocol,
     MessageBoundaryProtocol,
@@ -8,7 +9,7 @@ from slack_cli_hooks.protocol import (
 )
 
 PROTOCOL: Protocol
-EXEC = "python3"
+EXEC = sys.executable or "python3"
 
 
 hooks_payload = {

--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -9,7 +9,7 @@ from slack_cli_hooks.protocol import (
 )
 
 PROTOCOL: Protocol
-EXEC = sys.executable or "python3"
+EXEC = f"'{sys.executable}'" or "python3"
 
 
 hooks_payload = {

--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -10,7 +10,7 @@ from slack_cli_hooks.protocol import (
 
 PROTOCOL: Protocol
 
-# Stringify sys.executable to prevent execution failures if a white space is present in the absolute python path
+# Wrap sys.executable in quotes to prevent execution failures if a white space is present in the absolute python path
 EXEC = f"'{sys.executable}'" or "python3"
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

This PR changes which python executable is used to populate the `get-hooks` payload.
This PR sets the python executable of other hooks command to the python executable used to run the `get-hooks` hook, defined in the `slack.json` file.

This allows developers to select which python executable the CLI must use to invoke hooks. This is accomplished by changing which executable is used to invoke the `get-hooks` hook. Here are some examples of "get-hooks" values.

Examples:
```json
"get-hooks": "python3 -m slack_cli_hooks.hooks.get_hooks"
"get-hooks": "python2 -m slack_cli_hooks.hooks.get_hooks" // this is an example do not use python2
"get-hooks": "pypy -m slack_cli_hooks.hooks.get_hooks"
"get-hooks": "path/to/a/specific/bin/python -m slack_cli_hooks.hooks.get_hooks"
```

### Testing

1. pull this branch
2. run `scripts/build_pypi_package.sh`
3. use the path to the generated `.whl` file to import the changes in a python project
4. In a python project run `pip install /path/to/python-slack-hooks/dist/slack_cli_hooks-0.0.1-py3-none-any.whl`
5. run `python3 -m slack_cli_hooks.hooks.get_hooks`
6. The the hooks values from the output should resemble `"/Users/bob/path/to/my/project/env_3.12.2/bin/python -m slack_cli_hooks.hooks.get_manifest"` and not `"python3 -m slack_cli_hooks.hooks.get_manifest"`

### Special notes

Here are the scenarios I've tested

* [x] unit tests 🟢 
* [x] Running the app with a global python executable using the `python3` alias in `slack.json` 🟢 
* [x] Running the app with a global python executable using the `python` alias in `slack.json` 🟢 
* [x] Running the app with a virtual environment set up and the `python3` alias in `slack.json` 🟢 
* [x] Running the app with a virtual environment set up and the `python` alias in `slack.json` 🟢 
* [x] Running the app with **no virtual environment** and the `/Users/bob/path/to/virtural/env/bolt-python-project/env_3.12.2/bin/python` alias set in `slack.json` 🟢 
* [x] Running the app with a virtual environment set up and using the python executable of a **different virtual environment** in the `slack.json` 🟢 
* [x] Running the app with a virtual environment set up but setting the python executable of a **different virtual environment** for the `"start"` hook only 🟢 
* [x] Running the app with a **pypy virtual environment** using the `python3` alias in `slack.json` 🟢 
* [x] Running the app with **no virtual environment** and using the python executable of a **pypy virtual environment** in the `slack.json` 🟢  
* [x] Running the app with a virtual environment set up that contains a `space` in the python executable path, ex: `./env 3.10.7/bin/python` using the `python3` alias in `slack.json` 🟢
* [x] Using `PowerShell` to run the app with a virtual environment set up that contains a `space` in the python executable path, ex: `./env 3.10.7/bin/python` using the `python3` alias in `slack.json` 🟢
 

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
