### PR TITLE
chore: align README pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 <p align="center">
     <a href="https://pypi.org/project/slack-cli-hooks/">
-        <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/slack-cli-hooks?style=flat-square"></a>
+        <img alt="Pypi - Badge" src="https://img.shields.io/badge/pypi-slack--cli--hooks-green"></a>
     <a href="https://pypi.org/project/slack-cli-hooks/">
-        <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-cli-hooks.svg?style=flat-square"></a>
+        <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/slack-cli-hooks"></a>
     <a href="https://codecov.io/gh/slackapi/python-slack-hooks">
-        <img alt="Codecov" src="https://img.shields.io/codecov/c/gh/slackapi/python-slack-hooks?style=flat-square"></a>
+        <img alt="Codecov" src="https://img.shields.io/codecov/c/gh/slackapi/python-slack-hooks"></a>
+    <br>
+    <a href="https://pypi.org/project/slack-cli-hooks/">
+        <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-cli-hooks.svg"></a>
 </p>
 
 This library defines the contract between the


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

This PR updates the readme to follow the same pattern found in `bolt`, the `sdk` and the `hooks` projects

### Testing

[Preview](https://github.com/slackapi/python-slack-hooks/blob/update-readme/README.md)

### Special notes

<!-- Any special notes reviewers should be aware of. -->

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
