### PR TITLE
chore: fix warnings in tests

### DIFF
--- a/tests/scenario_test/test_get_hooks.py
+++ b/tests/scenario_test/test_get_hooks.py
@@ -12,6 +12,9 @@ class TestGetHooks:
         cli_args = [get_hooks.__name__, "--protocol", "message-boundaries", "--boundary", ""]
         self.argv_mock = patch.object(sys, "argv", cli_args)
         self.argv_mock.start()
+        # Prevent unpredictable behavior from import order mismatch
+        if get_hooks.__name__ in sys.modules:
+            del sys.modules[get_hooks.__name__]
 
     def teardown_method(self):
         self.argv_mock.stop()

--- a/tests/scenario_test/test_get_hooks.py
+++ b/tests/scenario_test/test_get_hooks.py
@@ -9,18 +9,15 @@ from slack_cli_hooks.hooks import get_hooks, get_manifest, start
 class TestGetHooks:
 
     def setup_method(self):
-        cli_args = [get_hooks.__name__, "--protocol", "message-boundaries", "--boundary", ""]
+        cli_args = [get_hooks.__file__, "--protocol", "message-boundaries", "--boundary", ""]
         self.argv_mock = patch.object(sys, "argv", cli_args)
         self.argv_mock.start()
-        # Prevent unpredictable behavior from import order mismatch
-        if get_hooks.__name__ in sys.modules:
-            del sys.modules[get_hooks.__name__]
 
     def teardown_method(self):
         self.argv_mock.stop()
 
     def test_get_manifest(self, capsys):
-        runpy.run_module(get_hooks.__name__, run_name="__main__")
+        runpy.run_path(get_hooks.__file__, run_name="__main__")
 
         out, err = capsys.readouterr()
         json_response = json.loads(out)
@@ -29,7 +26,7 @@ class TestGetHooks:
         assert get_manifest.__name__ in json_response["hooks"]["get-manifest"]
 
     def test_start(self, capsys):
-        runpy.run_module(get_hooks.__name__, run_name="__main__")
+        runpy.run_path(get_hooks.__file__, run_name="__main__")
 
         out, err = capsys.readouterr()
         json_response = json.loads(out)

--- a/tests/scenario_test/test_get_manifest.py
+++ b/tests/scenario_test/test_get_manifest.py
@@ -17,6 +17,9 @@ class TestGetManifest:
         self.argv_mock = patch.object(sys, "argv", cli_args)
         self.argv_mock.start()
         self.cwd = os.getcwd()
+        # Prevent unpredictable behavior from import order mismatch
+        if get_manifest.__name__ in sys.modules:
+            del sys.modules[get_manifest.__name__]
 
     def teardown_method(self):
         os.chdir(self.cwd)

--- a/tests/scenario_test/test_get_manifest.py
+++ b/tests/scenario_test/test_get_manifest.py
@@ -13,13 +13,10 @@ from slack_cli_hooks.hooks import get_manifest
 class TestGetManifest:
 
     def setup_method(self):
-        cli_args = [get_manifest.__name__, "--protocol", "message-boundaries", "--boundary", ""]
+        cli_args = [get_manifest.__file__, "--protocol", "message-boundaries", "--boundary", ""]
         self.argv_mock = patch.object(sys, "argv", cli_args)
         self.argv_mock.start()
         self.cwd = os.getcwd()
-        # Prevent unpredictable behavior from import order mismatch
-        if get_manifest.__name__ in sys.modules:
-            del sys.modules[get_manifest.__name__]
 
     def teardown_method(self):
         os.chdir(self.cwd)
@@ -29,7 +26,7 @@ class TestGetManifest:
         working_directory = "tests/scenario_test/test_app"
         os.chdir(working_directory)
 
-        runpy.run_module(get_manifest.__name__, run_name="__main__")
+        runpy.run_path(get_manifest.__file__, run_name="__main__")
 
         out, err = capsys.readouterr()
         assert err == ""
@@ -40,6 +37,6 @@ class TestGetManifest:
         os.chdir(working_directory)
 
         with pytest.raises(CliError) as e:
-            runpy.run_module(get_manifest.__name__, run_name="__main__")
+            runpy.run_path(get_manifest.__file__, run_name="__main__")
 
         assert str(e.value) == "Could not find a manifest.json file"

--- a/tests/scenario_test/test_start.py
+++ b/tests/scenario_test/test_start.py
@@ -27,6 +27,9 @@ class TestStart:
         self.argv_mock.start()
 
         self.cwd = os.getcwd()
+        # Prevent unpredictable behavior from import order mismatch
+        if start.__name__ in sys.modules:
+            del sys.modules[start.__name__]
 
     def teardown_method(self):
         self.argv_mock.stop()

--- a/tests/scenario_test/test_start.py
+++ b/tests/scenario_test/test_start.py
@@ -22,14 +22,11 @@ class TestStart:
         setup_mock_web_api_server(self)
         start_socket_mode_server(self, 3012)
 
-        cli_args = [start.__name__, "--protocol", "message-boundaries", "--boundary", ""]
+        cli_args = [start.__file__, "--protocol", "message-boundaries", "--boundary", ""]
         self.argv_mock = patch.object(sys, "argv", cli_args)
         self.argv_mock.start()
 
         self.cwd = os.getcwd()
-        # Prevent unpredictable behavior from import order mismatch
-        if start.__name__ in sys.modules:
-            del sys.modules[start.__name__]
 
     def teardown_method(self):
         self.argv_mock.stop()
@@ -44,7 +41,7 @@ class TestStart:
     def test_start_script(self, capsys, caplog):
         os.chdir(self.working_directory)
 
-        runpy.run_module(start.__name__, run_name="__main__")
+        runpy.run_path(start.__file__, run_name="__main__")
 
         captured_sys = capsys.readouterr()
 
@@ -55,7 +52,7 @@ class TestStart:
         os.environ["SLACK_APP_PATH"] = "my_app.py"
         os.chdir(self.working_directory)
 
-        runpy.run_module(start.__name__, run_name="__main__")
+        runpy.run_path(start.__file__, run_name="__main__")
 
         captured_sys = capsys.readouterr()
 
@@ -67,6 +64,6 @@ class TestStart:
         os.chdir(working_directory)
 
         with pytest.raises(CliError) as e:
-            runpy.run_module(start.__name__, run_name="__main__")
+            runpy.run_path(start.__file__, run_name="__main__")
 
         assert "Could not find app.py file" in str(e.value)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

This PR fixes the warnings in the tests. They originated from miss ordered imported modules, this is due to the way the tests are executed. These changes force python to load the module from scratch.

### Testing

Pull this branch, run the tests

### Special notes

<!-- Any special notes reviewers should be aware of. -->

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
