### PR TITLE
health: update the image used to run the CI pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   build:
-    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     strategy:
       matrix:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

This PR aims to unblock failing continuous testing pipelines. The changes update the image used by the gitthub action to the latest ubuntu version.

### Testing

N/A

### Special notes

This Change should have no impact since this project supports `python 3.9` and above 

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
