### PR TITLE
fix: redirect links to the changelog to the current changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 </p>
 
 This library defines the contract between the
-[Slack CLI](https://api.slack.com/automation/cli/install) and
+[Slack CLI](https://tools.slack.dev/slack-cli/) and
 [Bolt for Python](https://slack.dev/bolt-python/).
 
 ## Overview
 
-This library enables inter-process communication between the [Slack CLI](https://api.slack.com/automation/cli/install) and applications built with Bolt for Python.
+This library enables inter-process communication between the [Slack CLI](https://tools.slack.dev/slack-cli/) and applications built with Bolt for Python.
 
 When used together, the CLI delegates various tasks to the Bolt application by invoking processes ("hooks") and then making use of the responses provided by each hook's `stdout`.
 

--- a/slack_cli_hooks/__init__.py
+++ b/slack_cli_hooks/__init__.py
@@ -1,7 +1,7 @@
 """
-A Slack CLI hooks implementation in Python to build Bolt Slack apps leveraging the full power of the [Slack CLI](https://api.slack.com/automation/cli/install). Look at our [code examples](https://github.com/slackapi/python-slack-hooks/tree/main/examples) to learn how to build apps using the SLack CLI and Bolt.
+A Slack CLI hooks implementation in Python to build Bolt Slack apps leveraging the full power of the [Slack CLI](https://tools.slack.dev/slack-cli/). Look at our [code examples](https://github.com/slackapi/python-slack-hooks/tree/main/examples) to learn how to build apps using the SLack CLI and Bolt.
 
-* Slack CLI: https://api.slack.com/automation/cli/install
+* Slack CLI: https://tools.slack.dev/slack-cli/
 * Bolt Website: https://slack.dev/bolt-python/
 * GitHub repository: https://github.com/slackapi/python-slack-hooks
 """  # noqa: E501

--- a/slack_cli_hooks/hooks/__init__.py
+++ b/slack_cli_hooks/hooks/__init__.py
@@ -1,2 +1,1 @@
-"""Slack CLI contract implementation for Bolt.
-"""
+"""Slack CLI contract implementation for Bolt."""

--- a/slack_cli_hooks/hooks/check_update.py
+++ b/slack_cli_hooks/hooks/check_update.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import json
-from http.client import HTTPResponse
 import sys
+from http.client import HTTPResponse
 from types import ModuleType
 from typing import Any, Dict, List, Optional, TypedDict
 from urllib import request
@@ -91,7 +91,7 @@ def build_release(dependency: ModuleType) -> Release:
 
 
 def build_output(dependencies: List[ModuleType] = DEPENDENCIES) -> OutputType:
-    output: OutputType = {"name": "Slack Bolt", "url": "https://api.slack.com/automation/changelog", "releases": []}
+    output: OutputType = {"name": "Slack Bolt", "url": "https://docs.slack.dev/changelog", "releases": []}
     errors = []
 
     for dep in dependencies:

--- a/tests/slack_cli_hooks/hooks/test_check_update.py
+++ b/tests/slack_cli_hooks/hooks/test_check_update.py
@@ -145,6 +145,6 @@ class TestCheckUpdate:
 
         assert actual == {
             "name": "Slack Bolt",
-            "url": "https://api.slack.com/automation/changelog",
+            "url": "https://docs.slack.dev/changelog",
             "releases": [],
         }


### PR DESCRIPTION
### Summary

This PR replaces the link to the `CHANGELOG` to be: https://docs.slack.dev/changelog 📚 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
