### PR TITLE
fix: use existing executable or unversioned python

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Below is an example `/slack.json` file that overrides the default `start`:
 ```json
 {
   "hooks": {
-    "get-hooks": "python3 -m slack_cli_hooks.hooks.get_hooks",
-    "start": "python3 app.py"
+    "get-hooks": "python -m slack_cli_hooks.hooks.get_hooks",
+    "start": "python app.py"
   }
 }
 ```

--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -7,7 +7,7 @@ from slack_cli_hooks.protocol import DefaultProtocol, MessageBoundaryProtocol, P
 PROTOCOL: Protocol
 
 # Wrap sys.executable in quotes to prevent execution failures if a white space is present in the absolute python path
-EXEC = f"'{sys.executable}'" or "python3"
+EXEC = f"'{sys.executable}'" if sys.executable else "python"
 
 
 hooks_payload = {

--- a/slack_cli_hooks/hooks/get_hooks.py
+++ b/slack_cli_hooks/hooks/get_hooks.py
@@ -7,7 +7,10 @@ from slack_cli_hooks.protocol import DefaultProtocol, MessageBoundaryProtocol, P
 PROTOCOL: Protocol
 
 # Wrap sys.executable in quotes to prevent execution failures if a white space is present in the absolute python path
-EXEC = f"'{sys.executable}'" if sys.executable else "python"
+if sys.executable:
+    EXEC = f"& '{sys.executable}'" if sys.platform == "win32" else f"'{sys.executable}'"
+else:
+    EXEC = "python"
 
 
 hooks_payload = {

--- a/tests/slack_cli_hooks/hooks/test_get_hooks.py
+++ b/tests/slack_cli_hooks/hooks/test_get_hooks.py
@@ -1,7 +1,22 @@
+import importlib
+import sys
+from unittest.mock import patch
+
+from slack_cli_hooks.hooks import get_hooks
 from slack_cli_hooks.hooks.get_hooks import hooks_payload
 
 
 class TestGetHooks:
+    def test_exec_uses_sys_executable(self):
+        with patch.object(sys, "executable", "/usr/bin/python3"):
+            importlib.reload(get_hooks)
+            assert get_hooks.EXEC == "'/usr/bin/python3'"
+
+    def test_exec_falls_back_to_python_when_sys_executable_is_empty(self):
+        with patch.object(sys, "executable", ""):
+            importlib.reload(get_hooks)
+            assert get_hooks.EXEC == "python"
+
     def test_hooks_payload(self):
         hooks = hooks_payload["hooks"]
 

--- a/tests/slack_cli_hooks/hooks/test_get_hooks.py
+++ b/tests/slack_cli_hooks/hooks/test_get_hooks.py
@@ -8,9 +8,14 @@ from slack_cli_hooks.hooks.get_hooks import hooks_payload
 
 class TestGetHooks:
     def test_exec_uses_sys_executable(self):
-        with patch.object(sys, "executable", "/usr/bin/python3"):
+        with patch.object(sys, "executable", "/usr/bin/python3"), patch.object(sys, "platform", "linux"):
             importlib.reload(get_hooks)
             assert get_hooks.EXEC == "'/usr/bin/python3'"
+
+    def test_exec_uses_call_operator_on_windows(self):
+        with patch.object(sys, "executable", "C:\\Python\\python.exe"), patch.object(sys, "platform", "win32"):
+            importlib.reload(get_hooks)
+            assert get_hooks.EXEC == "& 'C:\\Python\\python.exe'"
 
     def test_exec_falls_back_to_python_when_sys_executable_is_empty(self):
         with patch.object(sys, "executable", ""):


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

This PR uses the existing executable or an unversioned `python` command otherwise. Fixes #70.

### Testing

WIP.

### Special notes

These changes shouldn't break the experience for Unix, despite the `python3` alias being somewhat common. I understand that this option is most relevant when creating a virtual environment, but afterward all aliases point to the same version it seems:

```
(.venv) $ ls .venv/bin
python -> python3.13*
python3 -> python3.13*
python3.13 -> /opt/homebrew/opt/python@3.13/bin/python3.13*
```

Windows setups don't include aliases from what I find:

```
(.venv) PS C:> ls .\.venv\Scripts
python.exe
(.venv) PS C:> python --version
Python 3.14.0
```

We might make additional changes to the upstream `init` command if this seems correct as well:

https://github.com/slackapi/slack-cli/blob/a2df7c635e6ba442f51220f6a88c57ed9b64b521/internal/runtime/python/hooks.json#L3

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-hooks/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_and_run_tests.sh` after making the changes.
