### PR TITLE
ci: configure dependabot to ignore slack-bolt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # Maintainers bump the minimum slack-bolt version manually so the project
+      # does not always require the latest release.
+      - dependency-name: "slack-bolt"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Dependabot keeps opening PRs that bump the **minimum** `slack-bolt` version in `requirements.txt` (e.g. #122, #125). We don't want this project to always require the latest `slack-bolt`, maintainers will bump the minimum version manually when there's a real reason to.

This adds an `ignore` entry for `slack-bolt` under the `pip` ecosystem in `.github/dependabot.yml`, so Dependabot stops proposing these bumps. All other pip and github-actions updates are unaffected.


Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>